### PR TITLE
average temp and humidity fixed, energy rounds to first decimal point

### DIFF
--- a/portal/app/api/v1/endpoint/farm_data_parser.py
+++ b/portal/app/api/v1/endpoint/farm_data_parser.py
@@ -63,11 +63,14 @@ def main_power_parser(data):
 
     farm_df = pd.DataFrame(farm_data)
     farm_df["POWER_TEST_PEN"] = farm_df["POWER_TEST_PEN"].abs() / 1000
+    # energy = power/12
     farm_df["energy"] = farm_df["POWER_TEST_PEN"] / 12
+    # energy column rounded to first decimal
+    farm_df["energy"] = farm_df["energy"].round(1)
     # timezone changed from utc to pacific
     farm_df["timestamp"] = utc_to_pst(farm_df["timestamp"])
     # round df values
-    farm_df = df_round(farm_df)
+    farm_df = df_round(farm_df,["timestamp", "energy"])
 
     return farm_df.to_json(date_format="iso")
 

--- a/portal/app/api/v1/endpoint/farm_data_parser.py
+++ b/portal/app/api/v1/endpoint/farm_data_parser.py
@@ -63,9 +63,8 @@ def main_power_parser(data):
 
     farm_df = pd.DataFrame(farm_data)
     farm_df["POWER_TEST_PEN"] = farm_df["POWER_TEST_PEN"].abs() / 1000
-    # energy = power/12
+
     farm_df["energy"] = farm_df["POWER_TEST_PEN"] / 12
-    # energy column rounded to first decimal
     farm_df["energy"] = farm_df["energy"].round(1)
     # timezone changed from utc to pacific
     farm_df["timestamp"] = utc_to_pst(farm_df["timestamp"])

--- a/portal/app/core/assets/js/main-farm.js
+++ b/portal/app/core/assets/js/main-farm.js
@@ -1,11 +1,11 @@
-var averageHum = math.mean(Object.keys(tempHum["rel_humidity"]));
-var averageTemp = math.mean(Object.keys(tempHum["temperature"]));
+var averageHum = math.mean(Object.values(tempHum["rel_humidity"]));
+var averageTemp = math.mean(Object.values(tempHum["temperature"]));
 
-$("#average-temp").html(Math.round(averageTemp * (9 / 5) + 32) + "F");
-$("#average-temp2").html(Math.round(averageTemp * (9 / 5) + 32) + "F");
+$("#average-temp").html(Math.round(averageTemp) + "F");
+$("#average-temp2").html(Math.round(averageTemp) + "F");
 
-$("#average-hum").html(Math.abs(averageHum) + "%");
-$("#average-hum2").html(Math.abs(averageHum) + "%");
+$("#average-hum").html(Math.round(averageHum) + "%");
+$("#average-hum2").html(Math.round(averageHum) + "%");
 
 $("#pen1").html(Math.round(Math.abs(penPower["POWER_TEST_PEN"])) + "W");
 $("#pen2").html(Math.round(Math.abs(penPower["CONTROL_FAN_POWER"])) + "W");


### PR DESCRIPTION
# Code changes
1) main_farm.js code changed to get value instead of key for average humidity and temperature
- temperature value is not converted to fahrenheit
- humidity value is rounded instead of taking absolut value
2) energy column is rounded to first decimal point

# Documentation changes
none

# Validation suggestions
1. run portal with farm account